### PR TITLE
Restore original Pipe name and description

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ The router currently supports these categories:
 
 1. Copy `prompt-router.py` into your OpenWebUI **Functions** directory or upload it via the Admin UI.
 2. Restart OpenWebUI.  
-3. In the model selector, you will see a new entry: **Auto-select model**.  
+3. In the model selector, you will see a new entry: **Auto Prompt Router**.
 4. Select it, and the router will automatically classify and forward prompts.
 
 ---

--- a/prompt-router.py
+++ b/prompt-router.py
@@ -308,6 +308,19 @@ if OPENWEBUI:
             except Exception:
                 pass
 
+    def pipes() -> list[dict[str, Any]]:
+        return [
+            {
+                "id": "prompt-router",
+                "name": "Auto Prompt Router",
+                "description": (
+                    "Automatically select the right model based on your prompt. "
+                    "Chooses between GPT-4o, GPT-4o-mini, Claude 4 Sonnet and Pixtral Large."
+                ),
+                "pipe": Pipe().pipe,
+            }
+        ]
+
 
 # ---------------------------------------------------------------------------
 # Local CLI test mode


### PR DESCRIPTION
## Summary
- restore Auto Prompt Router name and original description
- expose pipe metadata via `pipes()` to display in OpenWebUI
- update docs to reflect new model name

## Testing
- `python -m py_compile prompt-router.py`


------
https://chatgpt.com/codex/tasks/task_e_68b4a4de0988832286453976484b2352