### PR TITLE
fix: restore pipe metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,10 +35,23 @@ The router currently supports these categories:
 
 ## Usage in OpenWebUI
 
-1. Copy `prompt-router.py` into your OpenWebUI **Functions** directory or upload it via the Admin UI.
-2. Restart OpenWebUI.  
-3. In the model selector, you will see a new entry: **Auto-select model**.  
-4. Select it, and the router will automatically classify and forward prompts.
+1. Go to Admin → Functions → New in the OpenWebUI interface.
+2. Create a new Pipe Function, give it a meaningful name and description.
+3. Copy the entire Python code from `prompt-router.py` into the editor and save.
+4. Enable the function using the toggle.
+5. In the model selector, you will see a new entry: **Auto Prompt Router**.
+6. Select it, and the router will automatically classify and forward prompts.
+
+Check the Valves values to configure the router. Available options include:
+
+- `CLASSIFIER_MODEL_ID` – model ID used for classification.
+- `MODEL_DEFAULT` – model ID for default/smalltalk prompts.
+- `MODEL_CODING` – model ID for coding/tech prompts.
+- `MODEL_DEEP` – model ID for deep reasoning/complex queries.
+- `MODEL_STRUCT` – model ID for structured analysis.
+- `MODEL_CONTENT` – model ID for content generation.
+- `MODEL_VISION` – model ID for vision/multimodal prompts.
+- `PREFACE_ENABLED` – toggle to include or omit the routing preface.
 
 ---
 

--- a/prompt-router.py
+++ b/prompt-router.py
@@ -287,9 +287,7 @@ if OPENWEBUI:
 
         def _parse_classifier_label(self, response: Dict[str, Any]) -> str:
             try:
-                return response["choices"][0]["message"][
-                    "content"
-                ]  # type: ignore[index]
+                return response["choices"][0]["message"]["content"]  # type: ignore[index]
             except Exception:
                 return ""
 
@@ -308,6 +306,19 @@ if OPENWEBUI:
             except Exception:
                 pass
 
+    # ---------------------------------------------------------------------------
+    def pipes() -> list[dict[str, object]]:
+        return [
+            {
+                "id": "prompt-router",
+                "name": "Auto Prompt Router",
+                "description": (
+                    "Automatically select the right model based on your prompt. "
+                    "Chooses between GPT-4o, GPT-4o-mini, Claude 4 Sonnet and Pixtral Large."
+                ),
+                "pipe": Pipe,
+            }
+        ]
 
 # ---------------------------------------------------------------------------
 # Local CLI test mode


### PR DESCRIPTION
## Summary
- restore original pipe name and description
- register pipe metadata so description appears automatically in OpenWebUI
- update documentation to match restored name
- clarify OpenWebUI setup steps and valve options

## Testing
- `ruff format README.md` *(fails: Failed to parse README.md:3:6)*
- `ruff format prompt-router.py`


------
https://chatgpt.com/codex/tasks/task_e_68b4a4de0988832286453976484b2352