### PR TITLE
Include category in routing preface

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Check the Valves values to configure the router. Available options include:
 - `MODEL_STRUCT` – model ID for structured analysis.
 - `MODEL_CONTENT` – model ID for content generation.
 - `MODEL_VISION` – model ID for vision/multimodal prompts.
-- `PREFACE_ENABLED` – toggle to include or omit the routing preface.
+- `PREFACE_ENABLED` – toggle to include or omit the routing preface ("(detected {category} prompt, routing to {model})").
 
 ---
 

--- a/prompt-router.py
+++ b/prompt-router.py
@@ -58,10 +58,10 @@ def build_classifier_prompt(
     )
 
 
-def build_preface(model_id: str) -> str:
+def build_preface(category: str, model_id: str) -> str:
     """Return the markdown preface for routing information."""
 
-    return f"_(routing to: {model_id})_\n\n---\n\n"
+    return f"_(detected {category} prompt, routing to {model_id})_\n\n---\n\n"
 
 
 def choose_category_or_default(raw_label: str, categories: Dict[str, Any]) -> str:
@@ -257,7 +257,7 @@ if OPENWEBUI:
             if not self.valves.PREFACE_ENABLED:
                 return response
 
-            preface = build_preface(model_id)
+            preface = build_preface(category, model_id)
 
             if isinstance(response, StreamingResponse):
                 return wrap_stream_with_preface(response, preface)
@@ -319,6 +319,7 @@ if OPENWEBUI:
                 "pipe": Pipe,
             }
         ]
+
 
 # ---------------------------------------------------------------------------
 # Local CLI test mode


### PR DESCRIPTION
## Summary
- show both detected category and routed model in the preface
- document preface format in README

## Testing
- `black prompt-router.py`
- `python -m py_compile prompt-router.py`


------
https://chatgpt.com/codex/tasks/task_e_68b4aec0731483229fdce10ea890f0b4