### PR TITLE
refactor: consolidate helper functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,12 @@ Windows PowerShell:
 - In CLI mode, Bedrock is accessed directly via `boto3`.
 - If a model request fails, the router returns an error so you can manually select a model.
 
+## Manual test steps
+
+- Non-stream test and verify preface renders correctly (no Markdown heading).
+- Stream test and verify preface chunk arrives first.
+- Unknown category → error.
+
 ## License
 
 see LICENSE file


### PR DESCRIPTION
## Summary
- consolidate helper functions into one block at the bottom
- move manual test steps into README for better discoverability

## Testing
- `python -m black prompt-router.py`
- `python -m py_compile prompt-router.py`

------
https://chatgpt.com/codex/tasks/task_e_68b55b85acb4832282ceb2c6ec24aa1a