### PR TITLE
Add router logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,10 @@ Check the Valves values to configure the router. Available options include:
 - `MODEL_VISION` – model ID for vision/multimodal prompts.
 - `PREFACE_ENABLED` – toggle to include or omit the routing prefaces.
 
+## Logging
+
+The router logs the detected category, the requested model, and the model reported in the response at the INFO level.
+
 ---
 
 ## Local CLI Test with AWS Bedrock


### PR DESCRIPTION
## Summary
- add INFO-level logs before and after routing calls
- document logging behavior

## Testing
- `black prompt-router.py`
- `python -m py_compile prompt-router.py`


------
https://chatgpt.com/codex/tasks/task_e_68b55d68ea208322a5f0ffdbcea94081