### PR TITLE
Preserve upstream cleanup for streaming responses

### DIFF
--- a/prompt-router.py
+++ b/prompt-router.py
@@ -283,7 +283,12 @@ def wrap_stream_with_preface(
 
     headers = dict(getattr(upstream, "headers", {}) or {})
     headers.pop("content-length", None)
-    return StreamingResponse(stream(), media_type=upstream.media_type, headers=headers)
+    return StreamingResponse(
+        stream(),
+        media_type=upstream.media_type,
+        headers=headers,
+        background=getattr(upstream, "background", None),
+    )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- pass through background tasks when wrapping streaming responses to prevent unclosed `aiohttp` sessions

## Testing
- `python -m py_compile prompt-router.py`


------
https://chatgpt.com/codex/tasks/task_e_68b5647426cc8322b62057ba1731f7f9