### PR TITLE
Remove temporary logging and bump version to 1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,11 +52,6 @@ Check the Valves values to configure the router. Available options include:
 - `MODEL_CONTENT` – model ID for content generation.
 - `MODEL_VISION` – model ID for vision/multimodal prompts.
 - `ROUTING_STATUS_ENABLED` – toggle to include or omit routing status events.
-
-## Logging
-
-The router logs the detected category, the requested model, and the model reported in the response at the INFO level.
-
 ---
 
 ## Local CLI Test with AWS Bedrock

--- a/prompt-router.py
+++ b/prompt-router.py
@@ -3,11 +3,10 @@ title: Prompt Router Pipe
 author: sunborn23
 author_url: https://github.com/sunborn23
 repo_url: https://github.com/sunborn23/prompt-router
-version: 0.5
+version: 1.0
 """
 
 import json
-import logging
 import os
 import sys
 from typing import Any, Dict
@@ -24,11 +23,6 @@ except ImportError:  # Local CLI runtime
     import boto3
 
     OPENWEBUI = False
-
-
-logging.basicConfig(level=logging.INFO)
-logger = logging.getLogger(__name__)
-logger.setLevel(logging.INFO)
 
 
 # ---------------------------------------------------------------------------
@@ -165,9 +159,6 @@ if OPENWEBUI:
 
             category = raw_label.strip().lower()
             model_id = self.router.model_for(category)
-            logger.info(
-                "Detected category '%s'; requesting model '%s'", category, model_id
-            )
 
             if self.valves.ROUTING_STATUS_ENABLED and __event_emitter__:
                 await __event_emitter__(
@@ -189,7 +180,6 @@ if OPENWEBUI:
                 actual_model = response.headers.get("x-model", model_id)
             else:
                 actual_model = response.get("model", model_id)
-            logger.info("Response returned from model '%s'", actual_model)
             return response
 
         # ------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- drop temporary logging and simplify pipe logic
- bump router version to 1.0
- clean up README

## Testing
- `python -m py_compile prompt-router.py`


------
https://chatgpt.com/codex/tasks/task_e_68b5c334c9248322a0d7ca8d87138b39