### PR TITLE
Await final model response

### DIFF
--- a/prompt-router.py
+++ b/prompt-router.py
@@ -172,7 +172,7 @@ if OPENWEBUI:
                 )
 
             body["model"] = model_id
-            return generate_chat_completion(__request__, body, user)
+            return await generate_chat_completion(__request__, body, user)
 
         # ------------------------------------------------------------------
         # Helpers


### PR DESCRIPTION
## Summary
- ensure prompt router awaits model completion before returning to OpenWebUI

## Testing
- `python -m py_compile prompt-router.py`


------
https://chatgpt.com/codex/tasks/task_e_68b5cc4e73dc83229ea91a81ce05c591